### PR TITLE
fix: update springdoc-openapi version to 2.3.0 for Spring Boot 3.4.5 compatibility

### DIFF
--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.2.0</version>
+			<version>2.3.0</version>
 		</dependency>
 
 


### PR DESCRIPTION
fix: update springdoc-openapi version to 2.3.0 for Spring Boot 3.4.5 compatibility